### PR TITLE
Fix alignment issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ bytemuck = "1"
 crypto-bigint = "0.5"
 # TODO switch this back to crates.io before tagging release
 # risc0-bigint2 = { version = "1.2.1", features = ["unstable"] }
-# risc0-bigint2 = { git = "https://github.com/risc0/risc0.git", rev = "ac029674f588d6f913dab3f5ea96683c6a71b869", features = ["unstable"] }
-risc0-bigint2 = { path = "/Users/tzerrell/code/risc0/risc0/bigint2", features = ["unstable"]}
+risc0-bigint2 = { git = "https://github.com/risc0/risc0.git", rev = "ac029674f588d6f913dab3f5ea96683c6a71b869", features = ["unstable"] }
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dev-dependencies]
 risc0-zkvm = { version = "1.2.1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ bytemuck = "1"
 crypto-bigint = "0.5"
 # TODO switch this back to crates.io before tagging release
 # risc0-bigint2 = { version = "1.2.1", features = ["unstable"] }
-risc0-bigint2 = { git = "https://github.com/risc0/risc0.git", rev = "ac029674f588d6f913dab3f5ea96683c6a71b869", features = ["unstable"] }
+# risc0-bigint2 = { git = "https://github.com/risc0/risc0.git", rev = "ac029674f588d6f913dab3f5ea96683c6a71b869", features = ["unstable"] }
+risc0-bigint2 = { path = "/Users/tzerrell/code/risc0/risc0/bigint2", features = ["unstable"]}
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dev-dependencies]
 risc0-zkvm = { version = "1.2.1", default-features = false, features = [

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -162,11 +162,16 @@ impl Mul for Fq2 {
         let prime: [u32; 8] = bytemuck::cast(Fq::modulus().0);
         let prime_sqr: [u32; 16] = bytemuck::cast(Fq::modulus_squared().0);
 
-        let mut result = [0u128; 4];
-        let result_mut: &mut [u32; 16] = bytemuck::cast_mut(&mut result);
+        // We construct our result using u32s but will eventually need to interpret it as u128s, so
+        // we align to the u128 alignment (i.e. of 16 bytes)
+        #[repr(align(16))]
+        struct AlignedU32s {
+            val: [[u32; 8]; 2]
+        }
+        let mut result_mut = AlignedU32s{ val: [[0u32; 8]; 2] };
 
-        field::extfield_xxone_mul_flatout_256(&lhs, &rhs, &prime, &prime_sqr, result_mut);
-        let result: &[[u128; 2]; 2] = bytemuck::cast_ref(result_mut);
+        field::extfield_xxone_mul_256(&lhs, &rhs, &prime, &prime_sqr, &mut result_mut.val);
+        let result: &[[u128; 2]; 2] = bytemuck::cast_ref(&result_mut.val);
         Fq2 {
             c0: Fq::new(U256(result[0])).unwrap(),
             c1: Fq::new(U256(result[1])).unwrap(),

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -162,10 +162,11 @@ impl Mul for Fq2 {
         let prime: [u32; 8] = bytemuck::cast(Fq::modulus().0);
         let prime_sqr: [u32; 16] = bytemuck::cast(Fq::modulus_squared().0);
 
-        let mut result_mut = [[0u32; 8]; 2];
+        let mut result = [0u128; 4];
+        let result_mut: &mut [u32; 16] = bytemuck::cast_mut(&mut result);
 
-        field::extfield_xxone_mul_256(&lhs, &rhs, &prime, &prime_sqr, &mut result_mut);
-        let result: &[[u128; 2]; 2] = bytemuck::cast_ref(&result_mut);
+        field::extfield_xxone_mul_flatout_256(&lhs, &rhs, &prime, &prime_sqr, result_mut);
+        let result: &[[u128; 2]; 2] = bytemuck::cast_ref(result_mut);
         Fq2 {
             c0: Fq::new(U256(result[0])).unwrap(),
             c1: Fq::new(U256(result[1])).unwrap(),

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -165,13 +165,11 @@ impl Mul for Fq2 {
         // We construct our result using u32s but will eventually need to interpret it as u128s, so
         // we align to the u128 alignment (i.e. of 16 bytes)
         #[repr(align(16))]
-        struct AlignedU32s {
-            val: [[u32; 8]; 2]
-        }
-        let mut result_mut = AlignedU32s{ val: [[0u32; 8]; 2] };
+        struct AlignedU32s([[u32; 8]; 2]);
+        let mut result_mut = AlignedU32s([[0u32; 8]; 2]);
 
-        field::extfield_xxone_mul_256(&lhs, &rhs, &prime, &prime_sqr, &mut result_mut.val);
-        let result: &[[u128; 2]; 2] = bytemuck::cast_ref(&result_mut.val);
+        field::extfield_xxone_mul_256(&lhs, &rhs, &prime, &prime_sqr, &mut result_mut.0);
+        let result: &[[u128; 2]; 2] = bytemuck::cast_ref(&result_mut.0);
         Fq2 {
             c0: Fq::new(U256(result[0])).unwrap(),
             c1: Fq::new(U256(result[1])).unwrap(),


### PR DESCRIPTION
This addresses an alignment issue that was causing transient bugs due to unaligned `u128`s (that had been cast via `bytemuck` from `u32`s).